### PR TITLE
refactor: changed comparison for tests purpose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+coverage
 
 node_modules
 dist

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "test": "jest",
     "test:watch": "jest --watchAll",
+    "test:coverage" : "jest --coverage",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/src/hooks/useAuthentication.tsx
+++ b/src/hooks/useAuthentication.tsx
@@ -32,10 +32,10 @@ export function useAuthentication() {
     } catch (error) {
       console.log(error)
       if(error instanceof AxiosError) {
-        if(error.code === "ERR_NETWORK") return "network_error"
+        if(error.code === AxiosError.ERR_NETWORK) return "network_error"
         if(error.response?.status == 401) return "wrong_credentials"
-        return error
       }
+      return "unexpected error"
     }
   }
 
@@ -50,7 +50,6 @@ export function useAuthentication() {
       if(error instanceof AxiosError) {
         if(error.code == AxiosError.ERR_NETWORK) return "network_error"
         if(error.response?.data.message == "user already exists") return "already_exists"
-        return "not"
       }
       return "unexpected error"
     }

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -47,6 +47,10 @@ function Login() {
                 setIsLoading(false)
                 return messageApi.error("Erro de servidor")
             }
+            if(response === "unexpected error") {
+                setIsLoading(false)
+                return messageApi.error("Erro inesperado")
+            }
             setIsLoading(false)
             messageApi.success("Autenticado com sucesso!")
             setTimeout(() => {

--- a/src/pages/Register/index.tsx
+++ b/src/pages/Register/index.tsx
@@ -51,6 +51,10 @@ function Register() {
                 setIsLoading(false)
                 return messageApi.error("Erro de servidor")
             }
+            if(response == "unexpected error") {
+                setIsLoading(false)
+                return messageApi.error("Erro inesperado")
+            }
             setIsLoading(false)
             messageApi.success("Registrado com sucesso!")
             setTimeout(() => {


### PR DESCRIPTION
`error.code == "ERR_NETWORK"` **now is** ` error.code == AxiosError.ERR_NETWORK`
added `return "unexpected error"` at the final of both login and register methods

added one more comparison inside Login page and Register page:
```
if(response === "unexpected error") {
    setIsLoading(false)
    return messageApi.error("Erro inesperado")
}
```